### PR TITLE
Inform borrower if everyone signed

### DIFF
--- a/app/deed/sign/server.py
+++ b/app/deed/sign/server.py
@@ -6,7 +6,7 @@ def register_routes(blueprint, deed_api):
     @blueprint.route('/deed/<deed_id>/<borrower_id>/signature/',
                      methods=['POST'])
     def sign_deed(deed_id, borrower_id):
-        borrower_name = request.form['borrower_name']
+        borrower_name = request.json['borrower_name']
 
         def create_signature():
             return borrower_name + "_" + strftime("%d/%m/%Y_%H:%M:%S")

--- a/app/service/deed_api/implementation.py
+++ b/app/service/deed_api/implementation.py
@@ -1,5 +1,4 @@
 import requests
-
 from app import config
 
 DEED_API_BASE_HOST = config.DEED_API_BASE_HOST
@@ -9,5 +8,4 @@ def sign(deed_id, borrower_id, signature):
     json_body = {"signature": signature}
     url = DEED_API_BASE_HOST + "/deed/" + deed_id + "/" + borrower_id + "/" \
         + "signature/"
-    print("DeedAPI sign URL: " + url)
-    return requests.post(url, data=json_body)
+    return requests.post(url, json=json_body)

--- a/tests/deed/test_deed.py
+++ b/tests/deed/test_deed.py
@@ -1,5 +1,6 @@
 from tests.helpers import with_client, setUpApp, with_context
 import unittest
+import json
 
 
 class TestDeed(unittest.TestCase):
@@ -10,8 +11,11 @@ class TestDeed(unittest.TestCase):
     @with_client
     def test_sign_deed(self, client):
         borrower_name = "DS"
-        response = client.post('/deed/1/1/signature/',
-                               data={"borrower_name": borrower_name})
+        response = client.post(
+            '/deed/1/1/signature/',
+            data=json.dumps({"borrower_name": borrower_name}),
+            headers={'content-type': 'application/json'}
+        )
 
         assert response.status_code == 200
         assert borrower_name in response.data.decode()


### PR DESCRIPTION
This pull request implements pivotal story "Inform borrower if everyone signed".  The changes in this pull request modify scribe to handle and create json, which APIs really should do.

This pull request needs to be merged after https://github.com/LandRegistry/charges-deed-api/pull/18 and before https://github.com/LandRegistry/charges-borrower-frontend/pull/27.
